### PR TITLE
Added site seeds

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -31,7 +31,7 @@ class Handler extends ExceptionHandler
      */
     public function report(Exception $e)
     {
-        if ($this->shouldReport($e)) {
+        if ($this->shouldReport($e) && config('services.sentry.dsn')) {
             $client = new Raven_Client(config('services.sentry.dsn'), [
                 'curl_method' => 'async'
             ]);

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,4 @@
 {
-    "name": "laravel/laravel",
-    "description": "The Laravel Framework.",
-    "keywords": ["framework", "laravel"],
     "license": "MIT",
     "type": "project",
     "require": {
@@ -19,7 +16,7 @@
         "doctrine/dbal": "^2.5"
     },
     "require-dev": {
-        "fzaninotto/faker": "~1.4",
+        "fzaninotto/faker": "^1.5",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "~4.0",
         "phpspec/phpspec": "~2.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "471ec280646f66f637bbc4f69868bf50",
+    "hash": "afc7959926efa5bb8d037e5119a83455",
     "packages": [
         {
             "name": "barryvdh/laravel-debugbar",

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -12,9 +12,86 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
+        // clear existing records
+
+        User::truncate();
+        Site::truncate();
+
+        // add new records
+
         Model::unguard();
 
-        //
+        $faker = Faker\Factory::create();
+
+        $users = [
+            User::create([
+                'twitter_id'            => '42204825',
+                'twitter_nickname'      => 'waynethebrain',
+                'twitter_avatar'        => $faker->imageUrl(64, 64),
+                'cloudinary_url'        => $faker->imageUrl(30, 30),
+                'cloudinary_secure_url' => $faker->imageUrl(30, 30),
+                'is_admin'              => 1,
+                'authenticated_at'      => Carbon::now(),
+            ]),
+            User::create([
+                'twitter_id'            => '4475091',
+                'twitter_nickname'      => 'shawnroos',
+                'twitter_avatar'        => $faker->imageUrl(64, 64),
+                'cloudinary_url'        => $faker->imageUrl(30, 30),
+                'cloudinary_secure_url' => $faker->imageUrl(30, 30),
+                'is_admin'              => 1,
+                'authenticated_at'      => Carbon::now(),
+            ]),
+            User::create([
+                'twitter_id'            => '79140061',
+                'twitter_nickname'      => 'assertchris',
+                'twitter_avatar'        => $faker->imageUrl(64, 64),
+                'cloudinary_url'        => $faker->imageUrl(30, 30),
+                'cloudinary_secure_url' => $faker->imageUrl(30, 30),
+                'is_admin'              => 1,
+                'authenticated_at'      => Carbon::now(),
+            ]),
+            User::create([
+                'twitter_id'            => '45637904',
+                'twitter_nickname'      => 'mikkelz_za',
+                'twitter_avatar'        => $faker->imageUrl(64, 64),
+                'cloudinary_url'        => $faker->imageUrl(30, 30),
+                'cloudinary_secure_url' => $faker->imageUrl(30, 30),
+                'is_admin'              => 1,
+                'authenticated_at'      => Carbon::now(),
+            ]),
+            User::create([
+                'twitter_id'            => '104805799',
+                'twitter_nickname'      => 'waller_texas',
+                'twitter_avatar'        => $faker->imageUrl(64, 64),
+                'cloudinary_url'        => $faker->imageUrl(30, 30),
+                'cloudinary_secure_url' => $faker->imageUrl(30, 30),
+                'is_admin'              => 1,
+                'authenticated_at'      => Carbon::now(),
+            ]),
+        ];
+
+        $sites = [];
+
+        for ($i = 0; $i < 20; $i++) {
+            $site = Site::create([
+                'user_id'     => $faker->randomElement($users)->id,
+                'url'         => $faker->url,
+                'title'       => $faker->sentence,
+                'description' => join("\n\n", $faker->paragraphs),
+                'vote_count'  => $faker->numberBetween(0, 100),
+                'approved_at' => Carbon::now(),
+                'approved_by' => $faker->randomElement($users)->id,
+            ]);
+
+            if ($faker->randomDigit % 5 === 0) {
+                $site->featured_by = $faker->randomElement($users)->id;
+                $site->featured_at = Carbon::now();
+                $site->save();
+            }
+
+            $sites[] = $site;
+        }
 
         Model::reguard();
     }


### PR DESCRIPTION
https://github.com/we-are-next/www.larasites.com/issues/41

This PR also removes very Laravel-specific keys from `composer.json` and adds a catch for incorrectly configured sentry DSN.

~~In other news, it's a Good Idea™ to leave those twitter handles in there...~~

What I meant to say is; while rebasing, I saw that you had removed the user seeds. They're useful for seeding sites, so I was wondering if you would mind me adding them back in or if you'd prefer to fake all the data..?